### PR TITLE
Add window hint to allow OpenGL 3+ on macOS

### DIFF
--- a/src/main/kotlin/learnOpenGL/common/glfw.kt
+++ b/src/main/kotlin/learnOpenGL/common/glfw.kt
@@ -16,6 +16,11 @@ object glfw {
         GLFWErrorCallback.createPrint(System.err).set()
         if (!glfwInit())
             throw IllegalStateException("Unable to initialize GLFW")
+        
+        /* This window hint is required to use OpenGL 3.1+ on macOS */
+        windowHint {
+            forwardComp = true
+        }
     }
 
     fun windowHint(block: windowHint.() -> Unit) = windowHint.block()


### PR DESCRIPTION
How can we detect os and use forwardComp by default only on macOS?